### PR TITLE
Battle 2k3: fixed actor/enemy facing, horizontal ally/enemy selection 

### DIFF
--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -36,6 +36,7 @@ BattleCommands,easyrpg_sequential_order,f,Boolean,0xCA,False,0,1,If alternative 
 BattleCommands,easyrpg_disable_row_feature,f,Boolean,0xCB,False,0,1,If the row feature should be disabled in RPG Maker 2003 games
 BattleCommands,easyrpg_fixed_actor_facing_direction,f,Int32,0xCC,0,0,1,"If actor facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped)"
 BattleCommands,easyrpg_fixed_enemy_facing_direction,f,Int32,0xCD,0,0,1,"If enemy facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped)"
+BattleCommands,easyrpg_horizontal_ally_enemy_selection,f,Boolean,0xCE,False,0,1,If the ally/enemy selection should be controlled with Left/Right instead of Up/Down
 Actor,easyrpg_actorai,f,Int32,0xC9,-1,0,0,Default autobattle AI behavior of the actor
 Actor,easyrpg_prevent_critical,f,Boolean,0xCA,False,0,0,If the actor is protected against critical hits
 Actor,easyrpg_raise_evasion,f,Boolean,0xCB,False,0,0,If the actor has an increased evasion rate

--- a/generator/csv/fields_easyrpg.csv
+++ b/generator/csv/fields_easyrpg.csv
@@ -34,6 +34,8 @@ BattleCommands,easyrpg_default_atb_mode,f,Enum<SaveSystem_AtbMode>,0xC8,0,0,1,De
 BattleCommands,easyrpg_enable_battle_row_command,f,Boolean,0xC9,True,0,1,If the row command should be enabled in RPG Maker 2003 battles
 BattleCommands,easyrpg_sequential_order,f,Boolean,0xCA,False,0,1,If alternative and gauge style battles should behave like traditional style battles
 BattleCommands,easyrpg_disable_row_feature,f,Boolean,0xCB,False,0,1,If the row feature should be disabled in RPG Maker 2003 games
+BattleCommands,easyrpg_fixed_actor_facing_direction,f,Int32,0xCC,0,0,1,"If actor facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped)"
+BattleCommands,easyrpg_fixed_enemy_facing_direction,f,Int32,0xCD,0,0,1,"If enemy facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped)"
 Actor,easyrpg_actorai,f,Int32,0xC9,-1,0,0,Default autobattle AI behavior of the actor
 Actor,easyrpg_prevent_critical,f,Boolean,0xCA,False,0,0,If the actor is protected against critical hits
 Actor,easyrpg_raise_evasion,f,Boolean,0xCB,False,0,0,If the actor has an increased evasion rate

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -267,7 +267,11 @@ namespace LDB_Reader {
 			/** If alternative and gauge style battles should behave like traditional style battles */
 			easyrpg_sequential_order = 0xCA,
 			/** If the row feature should be disabled in RPG Maker 2003 games */
-			easyrpg_disable_row_feature = 0xCB
+			easyrpg_disable_row_feature = 0xCB,
+			/** If actor facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped) */
+			easyrpg_fixed_actor_facing_direction = 0xCC,
+			/** If enemy facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped) */
+			easyrpg_fixed_enemy_facing_direction = 0xCD
 		};
 	};
 	struct ChunkBattlerAnimation {

--- a/src/generated/lcf/ldb/chunks.h
+++ b/src/generated/lcf/ldb/chunks.h
@@ -271,7 +271,9 @@ namespace LDB_Reader {
 			/** If actor facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped) */
 			easyrpg_fixed_actor_facing_direction = 0xCC,
 			/** If enemy facing direction shouldn't ever change during battle (0=Disabled, 1=Always flipped, 2=Never flipped) */
-			easyrpg_fixed_enemy_facing_direction = 0xCD
+			easyrpg_fixed_enemy_facing_direction = 0xCD,
+			/** If the ally/enemy selection should be controlled with Left/Right instead of Up/Down */
+			easyrpg_horizontal_ally_enemy_selection = 0xCE
 		};
 	};
 	struct ChunkBattlerAnimation {

--- a/src/generated/lcf/rpg/battlecommands.h
+++ b/src/generated/lcf/rpg/battlecommands.h
@@ -104,6 +104,8 @@ namespace rpg {
 		bool easyrpg_enable_battle_row_command = true;
 		bool easyrpg_sequential_order = false;
 		bool easyrpg_disable_row_feature = false;
+		int32_t easyrpg_fixed_actor_facing_direction = 0;
+		int32_t easyrpg_fixed_enemy_facing_direction = 0;
 	};
 	inline std::ostream& operator<<(std::ostream& os, BattleCommands::Placement code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -149,7 +151,9 @@ namespace rpg {
 		&& l.easyrpg_default_atb_mode == r.easyrpg_default_atb_mode
 		&& l.easyrpg_enable_battle_row_command == r.easyrpg_enable_battle_row_command
 		&& l.easyrpg_sequential_order == r.easyrpg_sequential_order
-		&& l.easyrpg_disable_row_feature == r.easyrpg_disable_row_feature;
+		&& l.easyrpg_disable_row_feature == r.easyrpg_disable_row_feature
+		&& l.easyrpg_fixed_actor_facing_direction == r.easyrpg_fixed_actor_facing_direction
+		&& l.easyrpg_fixed_enemy_facing_direction == r.easyrpg_fixed_enemy_facing_direction;
 	}
 
 	inline bool operator!=(const BattleCommands& l, const BattleCommands& r) {

--- a/src/generated/lcf/rpg/battlecommands.h
+++ b/src/generated/lcf/rpg/battlecommands.h
@@ -106,6 +106,7 @@ namespace rpg {
 		bool easyrpg_disable_row_feature = false;
 		int32_t easyrpg_fixed_actor_facing_direction = 0;
 		int32_t easyrpg_fixed_enemy_facing_direction = 0;
+		bool easyrpg_horizontal_ally_enemy_selection = false;
 	};
 	inline std::ostream& operator<<(std::ostream& os, BattleCommands::Placement code) {
 		os << static_cast<std::underlying_type_t<decltype(code)>>(code);
@@ -153,7 +154,8 @@ namespace rpg {
 		&& l.easyrpg_sequential_order == r.easyrpg_sequential_order
 		&& l.easyrpg_disable_row_feature == r.easyrpg_disable_row_feature
 		&& l.easyrpg_fixed_actor_facing_direction == r.easyrpg_fixed_actor_facing_direction
-		&& l.easyrpg_fixed_enemy_facing_direction == r.easyrpg_fixed_enemy_facing_direction;
+		&& l.easyrpg_fixed_enemy_facing_direction == r.easyrpg_fixed_enemy_facing_direction
+		&& l.easyrpg_horizontal_ally_enemy_selection == r.easyrpg_horizontal_ally_enemy_selection;
 	}
 
 	inline bool operator!=(const BattleCommands& l, const BattleCommands& r) {

--- a/src/generated/ldb_battlecommands.cpp
+++ b/src/generated/ldb_battlecommands.cpp
@@ -167,6 +167,13 @@ static TypedField<rpg::BattleCommands, int32_t> static_easyrpg_fixed_enemy_facin
 	0,
 	1
 );
+static TypedField<rpg::BattleCommands, bool> static_easyrpg_horizontal_ally_enemy_selection(
+	&rpg::BattleCommands::easyrpg_horizontal_ally_enemy_selection,
+	LDB_Reader::ChunkBattleCommands::easyrpg_horizontal_ally_enemy_selection,
+	"easyrpg_horizontal_ally_enemy_selection",
+	0,
+	1
+);
 
 
 template <>
@@ -192,6 +199,7 @@ Field<rpg::BattleCommands> const* Struct<rpg::BattleCommands>::fields[] = {
 	&static_easyrpg_disable_row_feature,
 	&static_easyrpg_fixed_actor_facing_direction,
 	&static_easyrpg_fixed_enemy_facing_direction,
+	&static_easyrpg_horizontal_ally_enemy_selection,
 	NULL
 };
 

--- a/src/generated/ldb_battlecommands.cpp
+++ b/src/generated/ldb_battlecommands.cpp
@@ -153,6 +153,20 @@ static TypedField<rpg::BattleCommands, bool> static_easyrpg_disable_row_feature(
 	0,
 	1
 );
+static TypedField<rpg::BattleCommands, int32_t> static_easyrpg_fixed_actor_facing_direction(
+	&rpg::BattleCommands::easyrpg_fixed_actor_facing_direction,
+	LDB_Reader::ChunkBattleCommands::easyrpg_fixed_actor_facing_direction,
+	"easyrpg_fixed_actor_facing_direction",
+	0,
+	1
+);
+static TypedField<rpg::BattleCommands, int32_t> static_easyrpg_fixed_enemy_facing_direction(
+	&rpg::BattleCommands::easyrpg_fixed_enemy_facing_direction,
+	LDB_Reader::ChunkBattleCommands::easyrpg_fixed_enemy_facing_direction,
+	"easyrpg_fixed_enemy_facing_direction",
+	0,
+	1
+);
 
 
 template <>
@@ -176,6 +190,8 @@ Field<rpg::BattleCommands> const* Struct<rpg::BattleCommands>::fields[] = {
 	&static_easyrpg_enable_battle_row_command,
 	&static_easyrpg_sequential_order,
 	&static_easyrpg_disable_row_feature,
+	&static_easyrpg_fixed_actor_facing_direction,
+	&static_easyrpg_fixed_enemy_facing_direction,
 	NULL
 };
 

--- a/src/generated/rpg_battlecommands.cpp
+++ b/src/generated/rpg_battlecommands.cpp
@@ -42,6 +42,7 @@ std::ostream& operator<<(std::ostream& os, const BattleCommands& obj) {
 	os << ", easyrpg_disable_row_feature="<< obj.easyrpg_disable_row_feature;
 	os << ", easyrpg_fixed_actor_facing_direction="<< obj.easyrpg_fixed_actor_facing_direction;
 	os << ", easyrpg_fixed_enemy_facing_direction="<< obj.easyrpg_fixed_enemy_facing_direction;
+	os << ", easyrpg_horizontal_ally_enemy_selection="<< obj.easyrpg_horizontal_ally_enemy_selection;
 	os << "}";
 	return os;
 }

--- a/src/generated/rpg_battlecommands.cpp
+++ b/src/generated/rpg_battlecommands.cpp
@@ -40,6 +40,8 @@ std::ostream& operator<<(std::ostream& os, const BattleCommands& obj) {
 	os << ", easyrpg_enable_battle_row_command="<< obj.easyrpg_enable_battle_row_command;
 	os << ", easyrpg_sequential_order="<< obj.easyrpg_sequential_order;
 	os << ", easyrpg_disable_row_feature="<< obj.easyrpg_disable_row_feature;
+	os << ", easyrpg_fixed_actor_facing_direction="<< obj.easyrpg_fixed_actor_facing_direction;
+	os << ", easyrpg_fixed_enemy_facing_direction="<< obj.easyrpg_fixed_enemy_facing_direction;
 	os << "}";
 	return os;
 }


### PR DESCRIPTION
- add options to configure fixed actor/enemy facing during battle (0=Disabled[default]), 1=Always flipped, 2=Never flipped)
- add an option to configure horizontal ally/enemy selection during battle (False[default]/True)